### PR TITLE
Httpclient rewrite

### DIFF
--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -9,6 +9,37 @@ export enum Method {
     DELETE = "DELETE"
 };
 
+export enum ErrorType {
+    REQUEST,
+    RESPONSE
+}
+
+export abstract class Error {
+    private errorMsg: string;
+
+    constructor(msg: string) {
+        this.errorMsg = msg;
+    }
+
+    abstract type(): ErrorType;
+
+    msg(): string {
+        return this.errorMsg;
+    }
+}
+
+export class RequestError extends Error {
+    type(): ErrorType {
+        return ErrorType.REQUEST;
+    }
+}
+
+export class ResponseError extends Error {
+    type(): ErrorType {
+        return ErrorType.RESPONSE;
+    }
+}
+
 export class HttpClient {
     private basePath: string;
     app: VApp;
@@ -18,12 +49,28 @@ export class HttpClient {
         this.app = app;
     }
 
+    async perform(method: Method, path: string, data?: any, contentType = "application/json"): Promise<Response> {
+        return await this.doFetch(method, path, data, contentType);
+    }
+
     async peformGet(path: string): Promise<Response> {
         return await this.doFetch(Method.GET, path);
     }
 
     async performPost(path: string, data: any, contentType = "application/json"): Promise<Response> {
         return await this.doFetch(Method.POST, path, data, contentType);
+    }
+
+    async performPut(path: string, data: any, contentType = "application/json"): Promise<Response> {
+        return await this.doFetch(Method.PUT, path, data, contentType);
+    }
+
+    async performPatch(path: string, data: any, contentType = "application/json"): Promise<Response> {
+        return await this.doFetch(Method.PATCH, path, data, contentType);
+    }
+
+    async performDelete(path: string, data: any, contentType = "application/json"): Promise<Response> {
+        return await this.doFetch(Method.DELETE, path, data, contentType);
     }
 
     private async doFetch(method: Method, path: string, data?: any, contentType = "application/json"): Promise<Response> {
@@ -37,22 +84,24 @@ export class HttpClient {
             Object.assign(options, { "body": JSON.stringify(data) });
         }
 
-        const resp = await fetch(this.basePath + path, options);
+        try {
+            const resp = await fetch(this.basePath + path, options);
+            if (resp.status == 403 && !path.includes("token")) {
+                window.localStorage.removeItem("token");
+                window.sessionStorage.setItem("path", document.location.pathname);
+                await this.app.router.resolveRoute("/login");
+                return;
+            }
 
-        if (resp.status == 403 && !path.includes("token")) {
-            window.localStorage.removeItem("token");
-            window.sessionStorage.setItem("path", document.location.pathname);
-            await this.app.router.resolveRoute("/login");
-            return;
+            if (resp.status >= 300) {
+                throw new ResponseError(`Response with status code ${resp.status}: ${resp.statusText}`);
+            }
+
+            return resp;
+        } catch (error) {
+            throw new RequestError(`failed to fetch "${this.basePath + path}": ${error}`);
         }
-
-        if (resp.status >= 300) {
-            throw `Response with status code ${resp.status}: ${resp.statusText}`;
-        }
-
-        return resp;
     }
-
 
     private getHeader(contentType?: string): any {
         const token = window.localStorage.getItem("token");


### PR DESCRIPTION
This PR is a rewrite of the HttpClient. It provides the following:

- cleaner code because of de-duplication and async-await
- convenience methods for all HTTP Methods
- consistent error handling - perform<Method> now rejects on non 2xx status code, also with error.type() one can find out if the error comes from fetch() directly (failed request) or is beacause of a non 2xx status code (type() then yields "Response")

Let me know what you think